### PR TITLE
Remove intermediate file usage

### DIFF
--- a/cp_test_nn/bin.py
+++ b/cp_test_nn/bin.py
@@ -1,8 +1,10 @@
 import argparse
+import pickle
 
+from cp_test_nn import process
+from cp_test_nn.tokenizer import create_token_dict
 from cp_test_nn.create_network import create_network
 from cp_test_nn.predict import test_cv_success_rate
-from cp_test_nn.nn import NNWithScaler
 
 def main():
     parser = argparse.ArgumentParser(prog='cp_test_nn')
@@ -14,12 +16,15 @@ def main():
     args = parser.parse_args()
 
     if args.load:
-        network = NNWithScaler.load(args.load)
+        with open(args.load, 'rb') as f:
+            (tokens, network) = pickle.load(f)
     else:
-        network = create_network(args.trainingset)
+        tokens = create_token_dict(process.failures(args.trainingset))
+        network = create_network(args.trainingset, tokens)
 
     if args.serialize:
-        network.serialize(args.serialize)
+        with open(args.serialize, 'wb') as f:
+            pickle.dump((tokens, network), f)
 
     if args.cvset:
-        test_cv_success_rate(network, args.cvset)
+        test_cv_success_rate(network, tokens, args.cvset)

--- a/cp_test_nn/create_network.py
+++ b/cp_test_nn/create_network.py
@@ -1,13 +1,9 @@
-from cp_test_nn.process import process
-from cp_test_nn.tokenizer import create_token_dict
+from cp_test_nn import process
 from cp_test_nn.dataset import create_dataset
 from cp_test_nn.nn import NNWithScaler
-from cp_test_nn.util import FAILS_FILE, TOKEN_DICT_FILE, DATASET_FILE
 
-def create_network(input):
-    process(input, FAILS_FILE)
-    create_token_dict(FAILS_FILE, TOKEN_DICT_FILE)
-    create_dataset(FAILS_FILE, TOKEN_DICT_FILE, DATASET_FILE)
+def create_network(input, tokens):
+    data = create_dataset(process.failures(input), tokens)
     nn = NNWithScaler()
-    nn.train(DATASET_FILE)
+    nn.train(data)
     return nn

--- a/cp_test_nn/nn.py
+++ b/cp_test_nn/nn.py
@@ -1,6 +1,3 @@
-import json
-import pickle
-
 from sklearn.neural_network import MLPClassifier
 from sklearn.preprocessing import StandardScaler
 
@@ -13,22 +10,11 @@ class NNWithScaler:
         X = self.scaler.transform(X)
         return self.network.predict(X)
 
-    def train(self, dataset_file):
+    def train(self, data):
         X, y = [], []
-        with open(dataset_file) as f:
-            loaded = json.load(f)
-        X = loaded['dataset']
-        y = loaded['results']
+        X = data['dataset']
+        y = data['results']
 
         self.scaler.fit(X)
         X = self.scaler.transform(X)
         self.network.fit(X, y)
-
-    def serialize(self, path):
-        with open(path, 'wb') as f:
-            pickle.dump(self, f)
-
-    @classmethod
-    def load(cls, path):
-        with open(path, 'rb') as f:
-            return pickle.load(f)

--- a/cp_test_nn/predict.py
+++ b/cp_test_nn/predict.py
@@ -1,17 +1,10 @@
-import json
-
-from cp_test_nn.process import process
+from cp_test_nn import process
 from cp_test_nn.dataset import create_dataset
-from cp_test_nn.util import TOKEN_DICT_FILE, FAILS_CV_FILE, DATASET_CV_FILE
 
-def test_cv_success_rate(nn, cv_file):
-    process(cv_file, FAILS_CV_FILE)
-    create_dataset(FAILS_CV_FILE, TOKEN_DICT_FILE, DATASET_CV_FILE)
-    X, y = [], []
-    with open(DATASET_CV_FILE) as f:
-        cv = json.load(f)
-        X = cv['dataset']
-        y = cv['results']
+def test_cv_success_rate(nn, tokens, cv_file):
+    data = create_dataset(process.failures(cv_file), tokens)
+    X = data['dataset']
+    y = data['results']
 
     successes = 0
     false_negatives = 0

--- a/cp_test_nn/process.py
+++ b/cp_test_nn/process.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python3
 import json
 
-import json_lines
-
-def process(input_file, fails_file):
-    with json_lines.open(input_file) as i, open(fails_file, 'w') as o:
-        for item in i:
-            if item['status'] == 'failure':
-                json.dump(item, o)
-                o.write('\n')
+def failures(input_file):
+    with open(input_file) as f:
+        while True:
+            line = f.readline()
+            if not line:
+                break
+            if "failure" in line:
+                item = json.loads(line)
+                if item['status'] == 'failure':
+                    yield item

--- a/cp_test_nn/tokenizer.py
+++ b/cp_test_nn/tokenizer.py
@@ -1,9 +1,5 @@
 #!/usr/bin/python3
 import collections
-import json
-import re
-
-import json_lines
 
 from cp_test_nn.util import token_regexes, split_re, py_exception_re
 
@@ -34,21 +30,27 @@ def tokenize_log(log):
     return result
 
 
-def create_token_dict(fails_file, token_dict_file):
+def create_token_dict(items):
     # TODO: rename from "tokenizer" and "create_token_dict", since we're now
     #  adding not only tokens, but also contexts
     token_dict = collections.defaultdict(int)
     contexts = set()
     tests = set()
 
-    with json_lines.open(fails_file) as f:
-        for item in f:
-            for t in tokenize_log(item['log']):
-                token_dict[t] += 1
-            contexts.add(item['context'])
-            tests.add(item['test'])
+    for item in items:
+        for t in tokenize_log(item['log']):
+            token_dict[t] += 1
+        contexts.add(item['context'])
+        tests.add(item['test'])
 
-    with open(token_dict_file, 'w') as f:
-        json.dump({'tokens': token_dict,
-                   'contexts': sorted(contexts),
-                   'tests': sorted(tests)}, f)
+    tokens = {
+        'tokens': token_dict,
+        'contexts': sorted(contexts),
+        'tests': sorted(tests)
+    }
+
+    # Debugging code
+    # with open('tokens', 'wb') as f:
+    #     json.dump(tokens, f)
+
+    return tokens

--- a/cp_test_nn/util.py
+++ b/cp_test_nn/util.py
@@ -1,12 +1,5 @@
 import re
 
-FAILS_FILE = 'fails'
-TOKEN_DICT_FILE = 'tokens'
-DATASET_FILE = 'dataset'
-
-FAILS_CV_FILE = 'fails_cv'
-DATASET_CV_FILE = 'dataset_cv'
-
 SPECIAL_TOKEN_PREFIX = 'SpecialToken:'
 NUM_TOKEN = SPECIAL_TOKEN_PREFIX + 'Number'
 PERCENT_TOKEN = SPECIAL_TOKEN_PREFIX + 'Percent'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-json_lines
 scikit-learn
 scipy


### PR DESCRIPTION
This work is awesome! I'd like to integrate it into the Cockpit CI ... first just displaying the level of confidence about each failure and whether we know it's a flake or not, and start having the bots do periodic training.

Here's my first commit towards that.

------

Intermediate files makes sense for debugging, but results in a fragile system when using this in real life. Since we load all the data into memory in a single chunk anyway, this should result in no change in performance.

We also implement a single file for serializing state including tokens used when parsing later datasets.