### PR TITLE
Allow using custom threshold for classification probs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ A neural network that can easily be trained to recognize whether a CI fail is a 
 When you run `cp_test_nn`, you'll see bunch of numbers printed - these are progress of creating feature sets from the learning data set (`2017-06-21-2017-07-21-cockpit-test-data.jsonl`) and from validation set (`2017-06-22-2017-07-22-cockpit-test-data.jsonl`). When this is done (this might take couple minutes), the program will output something like:
 
 ```
-Success rate:  0.9759486905398183
-False positives:  0.009086050240513094
-False negatives:  0.014965259219668627
+Success rate: 0.9375314861460957
+False positives: 0.0015113350125944584
+False negatives: 0.02216624685138539
+Unsure: 0.038790931989924435
 ```
 
-Your numbers may vary slightly due to random initialization. Generally, success rate on the validation dataset above `0.95` is good - this shows that the approach is sound. The program is still in a very early phase and it should be possible to improve on this.
+Your numbers may vary slightly due to random initialization. Generally, success rate on the validation dataset above `0.9` is good - this shows that the approach is sound. The program is still in a very early phase and it should be possible to improve on this. Note that the success rate is artifically decreased by our choice to increase threshold that we consider safe to classify an example (it's `0.75`). This can be changed via the `-r <threshold>` commandline switch.
 
 The `-s serialized` will make the trained neural network serialize to file called `serialized`. On future invocations, you can use `-l serialized` instead of `-t ...` to load the serialized neural network instead of training it again.

--- a/cp_test_nn/bin.py
+++ b/cp_test_nn/bin.py
@@ -8,6 +8,13 @@ from cp_test_nn.tokenizer import create_token_dict
 from cp_test_nn.create_network import create_network
 from cp_test_nn.predict import predict
 
+def probability(f):
+    f = float(f)
+    if f < 0.5 or f > 1.0:
+        raise argparse.ArgumentTypeError('{} is not a number between 0.5 and 1.0'.format(f))
+    return f
+
+
 def main():
     parser = argparse.ArgumentParser(prog='cp_test_nn')
     group = parser.add_mutually_exclusive_group(required=True)
@@ -15,6 +22,9 @@ def main():
     group.add_argument('-l', '--load', help='Load serialized neural network from given file')
     parser.add_argument('-p', '--predict', help='Path to prediction or cross validation set of data')
     parser.add_argument('-s', '--serialize', help='Serialize trained neural network to given file')
+    parser.add_argument('-r', '--threshold', help='Probability threshold used to consider neural '
+                        'network result safe to use. Number between 0.5 and 1.0',
+                        type=probability)
     parser.add_argument('-q', '--quiet', help='Disable all logging output', action='store_true')
     parser.add_argument('-v', '--verbose', help='Provide verbose logging output',
                         action='store_true')
@@ -35,4 +45,7 @@ def main():
             pickle.dump((tokens, network), f)
 
     if args.predict:
-        predict(network, tokens, args.predict)
+        kwargs = {}
+        if args.threshold is not None:
+            kwargs['prob_thresh'] = args.threshold
+        predict(network, tokens, args.predict, **kwargs)

--- a/cp_test_nn/predict.py
+++ b/cp_test_nn/predict.py
@@ -6,8 +6,10 @@ from cp_test_nn.dataset import create_dataset
 
 logger = logging.getLogger(__name__)
 
+PREDICT_PROB_THRESHOLD = 0.75
 
-def predict(nn, tokens, cv_file):
+
+def predict(nn, tokens, cv_file, prob_thresh=PREDICT_PROB_THRESHOLD):
     logger.info('Predicting results')
     data = create_dataset(process.failures(cv_file), tokens)
     X = data['dataset']
@@ -17,32 +19,44 @@ def predict(nn, tokens, cv_file):
     successes = 0
     false_negatives = 0
     false_positives = 0
+    unsure = 0
     total_count = 0
 
     for i, item in enumerate(X):
-        pred = nn.predict([item])[0]
-        sys.stdout.write("{0} {1} {2} {3} {4}\n".format(
-            pred and "FLAKE  " or "NOT    ",
-            data["items"][i]["pull"],
-            data["items"][i]["test"],
-            data["items"][i]["context"],
-            data["items"][i].get("url", "")
+        pred_proba = nn.predict_proba([item])[0]
+        # we only assign 0 or 1 to pred if one of the probabilities is bigger than prob_thresh
+        pred = None
+        pred_text = "UNSURE "
+        if max(pred_proba) >= prob_thresh:
+            pred = int(pred_proba[1] >= pred_proba[0])
+            pred_text = "FLAKE  " if pred == 1 else "NOT    "
+
+        sys.stdout.write("{pred} {flake_proba:.6f} {p} {pull} {test} {context} {url}\n".format(
+            pred=pred_text,
+            flake_proba=pred_proba[1],
+            p=nn.predict([item])[0],
+            pull=data["items"][i]["pull"],
+            test=data["items"][i]["test"],
+            context=data["items"][i]["context"],
+            url=data["items"][i].get("url", "")
         ))
-        # TODO: Use the probability prediction to print data about how sure we are this is a flake
-        sys.stderr.write("  {0}\n  {1}\n".format(repr(nn.predict([item])), repr(nn.predict_proba([item]))))
+
         if y[i] >= 0:
-            logger.debug('Predicted item %d to be %d => %s', i + 1, pred,
+            logger.debug('Predicted item %d to be %d => %s', i + 1, pred_text.strip(),
                          'correct' if pred == y[i] else 'wrong')
             total_count += 1
             if pred == y[i]:
                 successes += 1
             elif pred == 1:
                 false_positives += 1
-            else:
+            elif pred == 0:
                 false_negatives += 1
+            else:
+                unsure += 1
 
     # Statistics
     if total_count:
         sys.stderr.write('Success rate: {0}\n'.format(successes / total_count))
         sys.stderr.write('False positives: {0}\n'.format(false_positives / total_count))
         sys.stderr.write('False negatives: {0}\n'.format(false_negatives / total_count))
+        sys.stderr.write('Unsure: {0}\n'.format(unsure / total_count))


### PR DESCRIPTION
This allows for arbitrary setting of what is the acceptable threshold for a prediction to be considered safe. The value defaults to 0.75 and can be changed via commandline invocation (`-r <threshold>`).
This PR also adds artificial classification result "UNSURE", which is used when the probability returned by the neural network is lower than the used threshold.

@stefwalter I'd like to hear your thoughts on this - does this make sense for your usecase?